### PR TITLE
Fixed inconsistency in Correios API

### DIFF
--- a/correios/correios.py
+++ b/correios/correios.py
@@ -63,7 +63,7 @@ class Correios(object):
                 declared_value_cost = float(service.find('ValorValorDeclarado').text.replace(',','.')),
                 home_delivery = True if service.find('EntregaDomiciliar').text == 'S' else False,
                 saturday_delivery = True if service.find('EntregaSabado').text == 'S' else False,
-                error_code = int(service.find('Erro').text) if service.find('Erro') is not None else 0,
+                error_code = int(service.find('Erro').text) if service.find('Erro') is not None and service.find('Erro').text is not None else 0,
                 error_message = service.find('MsgErro').text,
                 additional_information = service.find('obsFim').text
             ))

--- a/tests/resources/mock_correios_get_shipping_rate_multiple_service_result_success.xml
+++ b/tests/resources/mock_correios_get_shipping_rate_multiple_service_result_success.xml
@@ -10,7 +10,6 @@
         <ValorValorDeclarado>0,90</ValorValorDeclarado>
         <EntregaDomiciliar>S</EntregaDomiciliar>
         <EntregaSabado>N</EntregaSabado>
-        <Erro>0</Erro>
         <MsgErro></MsgErro>
         <obsFim></obsFim>
     </cServico>
@@ -24,6 +23,21 @@
         <ValorValorDeclarado>0,90</ValorValorDeclarado>
         <EntregaDomiciliar>S</EntregaDomiciliar>
         <EntregaSabado>S</EntregaSabado>
+        <Erro>0</Erro>
+        <MsgErro></MsgErro>
+        <obsFim></obsFim>
+    </cServico>
+    <cServico>
+        <Codigo>40215</Codigo>
+        <Valor>45,60</Valor>
+        <PrazoEntrega>1</PrazoEntrega>
+        <ValorSemAdicionais>40,00</ValorSemAdicionais>
+        <ValorMaoPropria>5,60</ValorMaoPropria>
+        <ValorAvisoRecebimento>0,00</ValorAvisoRecebimento>
+        <ValorValorDeclarado>0,00</ValorValorDeclarado>
+        <EntregaDomiciliar>S</EntregaDomiciliar>
+        <EntregaSabado>S</EntregaSabado>
+        <Erro></Erro>
         <MsgErro></MsgErro>
         <obsFim></obsFim>
     </cServico>


### PR DESCRIPTION
Sometimes Correios is returning an empty `Erro` child that means that there are no errors in the API call, so this PR fixes this inconsistency.